### PR TITLE
Rewrite stellar client without sodium and stellar-horizon dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,26 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-dependencies = [
- "generic-array 0.14.5",
-]
-
-[[package]]
-name = "aes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
-dependencies = [
- "aes-soft",
- "aesni",
- "cipher 0.2.5",
-]
-
-[[package]]
 name = "aes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,40 +80,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
-dependencies = [
- "aead",
- "aes 0.6.0",
- "cipher 0.2.5",
- "ctr 0.6.0",
- "ghash",
- "subtle",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher 0.2.5",
- "opaque-debug 0.3.0",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher 0.2.5",
  "opaque-debug 0.3.0",
 ]
 
@@ -212,125 +158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
-name = "async-channel"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-mutex",
- "blocking",
- "futures-lite",
- "num_cpus",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
-dependencies = [
- "concurrent-queue",
- "futures-lite",
- "libc",
- "log 0.4.16",
- "once_cell",
- "parking",
- "polling",
- "slab",
- "socket2",
- "waker-fn",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-sse"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6fa871e4334a622afd6bb2f611635e8083a6f5e2936c0f90f37c7ef9856298"
-dependencies = [
- "async-channel",
- "futures-lite",
- "http-types",
- "log 0.4.16",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils 0.8.8",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log 0.4.16",
- "memchr",
- "num_cpus",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,12 +177,6 @@ dependencies = [
  "quote 1.0.18",
  "syn 1.0.91",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30696a84d817107fc028e049980e09d5e140e8da8f1caeb17e8e950658a3cea9"
 
 [[package]]
 name = "async-trait"
@@ -387,12 +208,6 @@ checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
  "autocfg 1.1.0",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -661,20 +476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "blocking"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "borsh"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,12 +644,6 @@ dependencies = [
  "cipher 0.2.5",
  "ppv-lite86",
 ]
-
-[[package]]
-name = "cache-padded"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
@@ -1089,15 +884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
-dependencies = [
- "cache-padded",
-]
-
-[[package]]
 name = "console"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,23 +950,6 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "aes-gcm",
- "base64 0.13.0",
- "hkdf",
- "hmac 0.10.1",
- "percent-encoding 2.1.0",
- "rand 0.8.5",
- "sha2 0.9.9",
- "time 0.2.27",
- "version_check 0.9.4",
-]
-
-[[package]]
-name = "cookie"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f1c7727e460397e56abc4bddc1d49e07a1ad78fc98eb2e1c8f032a58a2f80d"
@@ -1214,18 +983,6 @@ checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
-
-[[package]]
-name = "crc16"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -1354,16 +1111,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
@@ -1379,25 +1126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
  "sct 0.6.1",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
-dependencies = [
- "quote 1.0.18",
- "syn 1.0.91",
-]
-
-[[package]]
-name = "ctr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
-dependencies = [
- "cipher 0.2.5",
 ]
 
 [[package]]
@@ -1433,41 +1161,6 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "strsim 0.10.0",
- "syn 1.0.91",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote 1.0.18",
- "syn 1.0.91",
 ]
 
 [[package]]
@@ -1845,8 +1538,8 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d47d900a7dea08593d398104f8288e37858b0ad714c8d08cd03fdb86563e6402"
 dependencies = [
- "aes 0.7.5",
- "ctr 0.7.0",
+ "aes",
+ "ctr",
  "digest 0.9.0",
  "hex",
  "hmac 0.11.0",
@@ -2118,12 +1811,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
-
-[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,21 +2073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,16 +2190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
-dependencies = [
- "opaque-debug 0.3.0",
- "polyval",
-]
-
-[[package]]
 name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,18 +2223,6 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2696,16 +2346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hkdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
-dependencies = [
- "digest 0.9.0",
- "hmac 0.10.1",
-]
-
-[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,16 +2362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
 dependencies = [
  "crypto-mac 0.9.1",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.1",
  "digest 0.9.0",
 ]
 
@@ -2785,28 +2415,6 @@ dependencies = [
  "bytes 1.1.0",
  "http",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel",
- "async-std",
- "base64 0.13.0",
- "cookie 0.14.4",
- "futures-lite",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url 2.2.2",
 ]
 
 [[package]]
@@ -2940,12 +2548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,12 +2661,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,12 +2753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "jsonrpc-client-transports"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,15 +2839,6 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log 0.4.16",
 ]
 
 [[package]]
@@ -3391,18 +2972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsodium-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "walkdir",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,7 +3012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
- "value-bag",
 ]
 
 [[package]]
@@ -4297,12 +3865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4634,30 +4196,6 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
-
-[[package]]
-name = "polling"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "log 0.4.16",
- "wepoll-ffi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "polyval"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
-dependencies = [
- "cpuid-bool",
- "opaque-debug 0.3.0",
- "universal-hash",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -5090,6 +4628,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "clap 3.1.8",
  "env_logger",
  "ethers",
@@ -5106,13 +4645,11 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sodiumoxide",
  "solana-client",
  "solana-sdk",
  "solana-transaction-status",
  "sp-core",
  "sp-storage",
- "stellar-horizon",
  "tendermint",
  "tendermint-proto",
  "tendermint-rpc",
@@ -5383,7 +4920,7 @@ version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c8b7d512d2fcac2316ebe590cde67573844b99e6cc9ee0f53375fa16e25ebd"
 dependencies = [
- "cookie 0.15.1",
+ "cookie",
  "either",
  "http",
  "hyper 0.14.18",
@@ -5413,17 +4950,6 @@ checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dc69eadbf0ee2110b8d20418c0c6edbaefec2811c4963dc17b6344e11fe0f8"
-dependencies = [
- "arrayvec 0.7.2",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -5757,17 +5283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding 2.1.0",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5788,29 +5303,6 @@ dependencies = [
  "itoa 1.0.1",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946fa04a8ac43ff78a1f4b811990afb9ddbdf5890b46d6dda0ba1998230138b7"
-dependencies = [
- "rustversion",
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
 ]
 
 [[package]]
@@ -6006,17 +5498,6 @@ checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "sodiumoxide"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7038b67c941e23501573cb7242ffb08709abe9b11eb74bceff875bbda024a6a8"
-dependencies = [
- "libc",
- "libsodium-sys",
- "serde",
 ]
 
 [[package]]
@@ -6952,54 +6433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
-name = "stellar-base"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c9250939fa02f29dc1b645e9ab2ac27bcf22732b7dafffe78e170e0a0301e4"
-dependencies = [
- "base32",
- "base64 0.13.0",
- "bitflags",
- "byteorder",
- "chrono",
- "crc16",
- "json",
- "num-bigint 0.2.6",
- "num-rational 0.3.2",
- "num-traits",
- "rust_decimal",
- "serde",
- "serde_json",
- "sodiumoxide",
- "thiserror",
- "xdr-rs-serialize",
- "xdr-rs-serialize-derive",
-]
-
-[[package]]
-name = "stellar-horizon"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e12bb676453293d9b64e8211870c19ace75cd9ff883337826c01da856ef8a53"
-dependencies = [
- "async-sse",
- "base64 0.12.3",
- "chrono",
- "futures 0.3.21",
- "http",
- "http-types",
- "hyper 0.14.18",
- "hyper-tls",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "stellar-base",
- "thiserror",
- "url 2.2.2",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7919,16 +7352,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "universal-hash"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7965,7 +7388,6 @@ dependencies = [
  "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
- "serde",
 ]
 
 [[package]]
@@ -7991,16 +7413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.0.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
-dependencies = [
- "ctor",
- "version_check 0.9.4",
-]
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8023,12 +7435,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -8264,15 +7670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8408,28 +7805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "xdr-rs-serialize"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bc1e5369f228d4fb05a58a64d03cf37f317712b3355e6ee2cc8cce431537ea"
-dependencies = [
- "base64 0.11.0",
- "hex",
- "json",
-]
-
-[[package]]
-name = "xdr-rs-serialize-derive"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de1017ed1803d107d4a7e5b5bb653b5e40fc9fa020383d42ceb1fed7c7bb5d"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
 ]
 
 [[package]]

--- a/src/realtps_common/src/chain.rs
+++ b/src/realtps_common/src/chain.rs
@@ -76,7 +76,6 @@ impl Chain {
             Chain::Rootstock,
             Chain::SecretNetwork,
             Chain::Solana,
-            #[cfg(feature = "stellar")]
             Chain::Stellar,
             Chain::Terra,
             Chain::XDai,

--- a/src/realtps_import/Cargo.toml
+++ b/src/realtps_import/Cargo.toml
@@ -26,9 +26,6 @@ solana-sdk = "1.9.9"
 solana-transaction-status = "1.9.9"
 sp-core = "4.0.0"
 sp-storage = "4.0.0"
-stellar-horizon = { version = "0.6.0", optional = true }
-# sodiumoxide broke API on 0.2.6 -> 0.2.7 but hey it's 0.x so whatever
-sodiumoxide = { version = "0.2.6", optional = true }
 near-jsonrpc-client = "0.2.0"
 near-primitives = "0.11.0"
 near-jsonrpc-primitives = "0.11.0"
@@ -37,11 +34,4 @@ tendermint = "0.23.3"
 tendermint-proto = "0.23.3"
 clap = { version = "3.0.2", features = ["derive"] }
 reqwest = "0.11.8"
-
-[features]
-# We set up "stellar" feature because
-# one of Stellar's dependencies "libsodium-sys" doesn't build on macOS.
-# use `cargo run --no-default-features` to disable Stellar when needed
-default = ["stellar"]
-stellar = ["stellar-horizon", "sodiumoxide"]
-
+chrono = "0.4.19"

--- a/src/realtps_import/src/client.rs
+++ b/src/realtps_import/src/client.rs
@@ -14,12 +14,6 @@ use solana_client::rpc_client::RpcClient;
 use solana_transaction_status::UiTransactionEncoding;
 use std::sync::Arc;
 use std::time::Duration;
-#[cfg(feature = "stellar")]
-use stellar_horizon::{
-    client::{HorizonClient, HorizonHttpClient},
-    request::{Order, PageRequest},
-    resources::Ledger,
-};
 use tendermint_rpc::{Client as TendermintClientTrait, HttpClient};
 use tokio::task;
 
@@ -294,55 +288,57 @@ impl Client for SolanaClient {
     }
 }
 
-#[cfg(feature = "stellar")]
 pub struct StellarClient {
-    client: HorizonHttpClient,
+    client: reqwest::Client,
+    url: String,
 }
 
-#[cfg(feature = "stellar")]
 impl StellarClient {
     pub fn new(url: &str) -> Result<Self> {
         Ok(Self {
-            client: HorizonHttpClient::new(url)?,
+            client: reqwest::Client::new(),
+            url: url.to_string(),
         })
     }
 }
 
-#[cfg(feature = "stellar")]
+#[derive(serde::Deserialize)]
+struct StellarNetworkDetailsResponse {
+    current_protocol_version: String,
+    history_latest_ledger: u32,
+}
+
+#[derive(serde::Deserialize)]
+struct StellarLedgerResponse {
+    closed_at: chrono::DateTime<chrono::Utc>,
+    hash: String,
+    prev_hash: String,
+    operation_count: u32,
+}
+
 #[async_trait]
 impl Client for StellarClient {
     async fn client_version(&self) -> Result<String> {
-        Ok(stellar_horizon::VERSION.into())
+        let resp = self.client.get(&self.url).send().await?;
+        let network_details: StellarNetworkDetailsResponse = resp.json().await?;
+        Ok(network_details.current_protocol_version)
     }
     async fn get_latest_block_number(&self) -> Result<u64> {
-        let req = stellar_horizon::api::ledgers::all()
-            .with_limit(1)
-            .with_order(&Order::Descending);
-        let (_headers, mut ledgers) = self.client.request(req).await?;
-        let ledger: Ledger = match ledgers.records.pop() {
-            Some(lg) => lg,
-            None => return Err(anyhow!("request returned empty set of ledgers")),
-        };
-        Ok(ledger.sequence as u64)
+        let resp = self.client.get(&self.url).send().await?;
+        let network_details: StellarNetworkDetailsResponse = resp.json().await?;
+        Ok(network_details.history_latest_ledger as u64)
     }
     async fn get_block(&self, block_number: u64) -> Result<Option<Block>> {
         if block_number > i32::MAX as u64 {
             return Err(anyhow!("ledger number out of range"));
         }
-        let req = stellar_horizon::api::ledgers::single(block_number as i32);
-        let (_headers, ledger) = self.client.request(req).await?;
-        let parent_hash = match ledger.previous_hash {
-            Some(h) => h,
-            None => return Err(anyhow!("missing parent hash")),
-        };
+        let url = format!("{}/ledgers/{}", &self.url, block_number);
+        let resp = self.client.get(url).send().await?;
+        let ledger: StellarLedgerResponse = resp.json().await?;
         Ok(Some(Block {
             chain: Chain::Stellar,
             block_number,
-            prev_block_number: if block_number > 0 {
-                Some(block_number - 1)
-            } else {
-                None
-            },
+            prev_block_number: Some(block_number - 1),
             timestamp: ledger.closed_at.timestamp() as u64,
             num_txs: ledger.operation_count as u64,
             // NB: operation_count corresponds most-closely to what is usually
@@ -353,7 +349,7 @@ impl Client for StellarClient {
             // unit in the protocol called a "transaction": operations are
             // sub-transactions, within the outer transaction object.
             hash: ledger.hash,
-            parent_hash,
+            parent_hash: ledger.prev_hash,
         }))
     }
 }

--- a/src/realtps_import/src/client.rs
+++ b/src/realtps_import/src/client.rs
@@ -304,7 +304,7 @@ impl StellarClient {
 
 #[derive(serde::Deserialize)]
 struct StellarNetworkDetailsResponse {
-    current_protocol_version: u32,
+    horizon_version: String,
     history_latest_ledger: u32,
 }
 
@@ -321,7 +321,7 @@ impl Client for StellarClient {
     async fn client_version(&self) -> Result<String> {
         let resp = self.client.get(&self.url).send().await?;
         let network_details: StellarNetworkDetailsResponse = resp.json().await?;
-        Ok(network_details.current_protocol_version.to_string())
+        Ok(network_details.horizon_version)
     }
     async fn get_latest_block_number(&self) -> Result<u64> {
         let resp = self.client.get(&self.url).send().await?;
@@ -365,7 +365,7 @@ mod test_stellar {
         let client = StellarClient::new(RPC_URL)?;
         let ver = client.client_version().await?;
         println!("client_version: {}", ver);
-        ver.parse::<u32>()?;
+        assert!(ver.len() > 0);
         Ok(())
     }
 

--- a/src/realtps_import/src/client.rs
+++ b/src/realtps_import/src/client.rs
@@ -304,15 +304,15 @@ impl StellarClient {
 
 #[derive(serde::Deserialize)]
 struct StellarNetworkDetailsResponse {
-    current_protocol_version: String,
+    current_protocol_version: u32,
     history_latest_ledger: u32,
 }
 
 #[derive(serde::Deserialize)]
 struct StellarLedgerResponse {
-    closed_at: chrono::DateTime<chrono::Utc>,
     hash: String,
     prev_hash: String,
+    closed_at: chrono::DateTime<chrono::Utc>,
     operation_count: u32,
 }
 
@@ -321,7 +321,7 @@ impl Client for StellarClient {
     async fn client_version(&self) -> Result<String> {
         let resp = self.client.get(&self.url).send().await?;
         let network_details: StellarNetworkDetailsResponse = resp.json().await?;
-        Ok(network_details.current_protocol_version)
+        Ok(network_details.current_protocol_version.to_string())
     }
     async fn get_latest_block_number(&self) -> Result<u64> {
         let resp = self.client.get(&self.url).send().await?;

--- a/src/realtps_import/src/client.rs
+++ b/src/realtps_import/src/client.rs
@@ -329,9 +329,6 @@ impl Client for StellarClient {
         Ok(network_details.history_latest_ledger as u64)
     }
     async fn get_block(&self, block_number: u64) -> Result<Option<Block>> {
-        if block_number > i32::MAX as u64 {
-            return Err(anyhow!("ledger number out of range"));
-        }
         let url = format!("{}/ledgers/{}", &self.url, block_number);
         let resp = self.client.get(url).send().await?;
         let ledger: StellarLedgerResponse = resp.json().await?;

--- a/src/realtps_import/src/client.rs
+++ b/src/realtps_import/src/client.rs
@@ -335,7 +335,11 @@ impl Client for StellarClient {
         Ok(Some(Block {
             chain: Chain::Stellar,
             block_number,
-            prev_block_number: Some(block_number - 1),
+            prev_block_number: if block_number > 0 {
+                Some(block_number - 1)
+            } else {
+                None
+            },
             timestamp: ledger.closed_at.timestamp() as u64,
             num_txs: ledger.operation_count as u64,
             // NB: operation_count corresponds most-closely to what is usually

--- a/src/realtps_import/src/client.rs
+++ b/src/realtps_import/src/client.rs
@@ -358,11 +358,11 @@ impl Client for StellarClient {
 mod test_stellar {
     use super::{Client, StellarClient};
 
-    const TEST_RPC_URL: &str = "https://horizon-testnet.stellar.org";
+    const RPC_URL: &str = "https://horizon.stellar.org";
 
     #[tokio::test]
     async fn client_version() -> Result<(), anyhow::Error> {
-        let client = StellarClient::new(TEST_RPC_URL)?;
+        let client = StellarClient::new(RPC_URL)?;
         let ver = client.client_version().await?;
         println!("client_version: {}", ver);
         ver.parse::<u32>()?;
@@ -371,7 +371,7 @@ mod test_stellar {
 
     #[tokio::test]
     async fn get_latest_block_number() -> Result<(), anyhow::Error> {
-        let client = StellarClient::new(TEST_RPC_URL)?;
+        let client = StellarClient::new(RPC_URL)?;
         let latest_block_number = client.get_latest_block_number().await?;
         println!("latest_block_number: {}", latest_block_number);
         assert!(latest_block_number > 0);
@@ -380,7 +380,7 @@ mod test_stellar {
 
     #[tokio::test]
     async fn get_block() -> Result<(), anyhow::Error> {
-        let client = StellarClient::new(TEST_RPC_URL)?;
+        let client = StellarClient::new(RPC_URL)?;
         let latest_block_number = client.get_latest_block_number().await?;
         println!("latest_block_number: {}", latest_block_number);
         let block = client.get_block(latest_block_number).await?;

--- a/src/realtps_import/src/client.rs
+++ b/src/realtps_import/src/client.rs
@@ -354,6 +354,41 @@ impl Client for StellarClient {
     }
 }
 
+#[cfg(test)]
+mod test_stellar {
+    use super::{Client, StellarClient};
+
+    const TEST_RPC_URL: &str = "https://horizon-testnet.stellar.org";
+
+    #[tokio::test]
+    async fn client_version() -> Result<(), anyhow::Error> {
+        let client = StellarClient::new(TEST_RPC_URL)?;
+        let ver = client.client_version().await?;
+        println!("client_version: {}", ver);
+        ver.parse::<u32>()?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_latest_block_number() -> Result<(), anyhow::Error> {
+        let client = StellarClient::new(TEST_RPC_URL)?;
+        let latest_block_number = client.get_latest_block_number().await?;
+        println!("latest_block_number: {}", latest_block_number);
+        assert!(latest_block_number > 0);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_block() -> Result<(), anyhow::Error> {
+        let client = StellarClient::new(TEST_RPC_URL)?;
+        let latest_block_number = client.get_latest_block_number().await?;
+        println!("latest_block_number: {}", latest_block_number);
+        let block = client.get_block(latest_block_number).await?;
+        println!("block: {:?}", block);
+        Ok(())
+    }
+}
+
 pub struct TendermintClient {
     chain: Chain,
     client: HttpClient,

--- a/src/realtps_import/src/main.rs
+++ b/src/realtps_import/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-#[cfg(feature = "stellar")]
-use client::StellarClient;
-use client::{Client, ElrondClient, EthersClient, NearClient, SolanaClient, TendermintClient};
+use client::{
+    Client, ElrondClient, EthersClient, NearClient, SolanaClient, StellarClient, TendermintClient,
+};
 use delay::retry_if_err;
 use futures::future::FutureExt;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -173,15 +173,7 @@ async fn make_client(chain: Chain, rpc_url: String) -> Result<Option<Box<dyn Cli
         ChainType::Ethers => Some(Box::new(EthersClient::new(chain, &rpc_url)?)),
         ChainType::Near => Some(Box::new(NearClient::new(&rpc_url)?)),
         ChainType::Solana => Some(Box::new(SolanaClient::new(&rpc_url)?)),
-        ChainType::Stellar => {
-            #[cfg(not(feature = "stellar"))]
-            let client = None;
-
-            #[cfg(feature = "stellar")]
-            let client: Option<Box<dyn Client>> = Some(Box::new(StellarClient::new(&rpc_url)?));
-
-            client
-        }
+        ChainType::Stellar => Some(Box::new(StellarClient::new(&rpc_url)?)),
         ChainType::Tendermint => Some(Box::new(TendermintClient::new(chain, &rpc_url)?)),
         ChainType::Substrate => Some(Box::new(SubstrateClient::new(chain, &rpc_url).await?)),
     };


### PR DESCRIPTION
### What
Rewrite the stellar client without the sodium and stellar-horizon dips.

### Why
Looks like the stellar-horizon dev has an inconvenient dependency on sodium that I see @Aimeedeer needed to move stellar into a feature for. The Stellar endpoints are stable and easy to parse so little need to pull in those deps.

cc @tomerweller @graydon 